### PR TITLE
Remove key from endpoint object

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,139 +14,117 @@ Atrium.endpoints = [
   {
     method: 'post',
     url: '/users',
-    clientMethod: 'createUser',
-    key: 'user'
+    clientMethod: 'createUser'
   },
   {
     method: 'get',
     url: '/users/:userGuid',
-    clientMethod: 'readUser',
-    key: 'user'
+    clientMethod: 'readUser'
   },
   {
     method: 'put',
     url: '/users/:userGuid',
-    clientMethod: 'updateUser',
-    key: 'user'
+    clientMethod: 'updateUser'
   },
   {
     method: 'delete',
     url: '/users/:userGuid',
-    clientMethod: 'deleteUser',
-    key: null
+    clientMethod: 'deleteUser'
   },
   //Institutions
   {
     method: 'get',
     url: '/institutions',
-    clientMethod: 'listInstitutions',
-    key: 'institutions'
+    clientMethod: 'listInstitutions'
   },
   //Credentials
   {
     method: 'get',
     url: '/institutions/:institutionCode/credentials',
-    clientMethod: 'listCredentials',
-    key: 'credentials'
+    clientMethod: 'listCredentials'
   },
   //Members
   {
     method: 'get',
     url: '/users/:userGuid/members',
-    clientMethod: 'listMembers',
-    key: 'members'
+    clientMethod: 'listMembers'
   },
   {
     method: 'post',
     url: '/users/:userGuid/members',
-    clientMethod: 'createMember',
-    key: 'member'
+    clientMethod: 'createMember'
   },
   {
     method: 'get',
     url: '/users/:userGuid/members/:memberGuid',
-    clientMethod: 'readMember',
-    key: 'member'
+    clientMethod: 'readMember'
   },
   {
     method: 'put',
     url: '/users/:userGuid/members/:memberGuid',
-    clientMethod: 'updateMember',
-    key: 'member'
+    clientMethod: 'updateMember'
   },
   {
     method: 'delete',
     url: '/users/:userGuid/members/:memberGuid',
-    clientMethod: 'deleteMember',
-    key: 'member'
+    clientMethod: 'deleteMember'
   },
   {
     method: 'post',
     url: '/users/:userGuid/members/:memberGuid/aggregate',
-    clientMethod: 'aggregateMember',
-    key: null
+    clientMethod: 'aggregateMember'
   },
   {
     method: 'put',
     url: '/users/:userGuid/members/:memberGuid/resume',
-    clientMethod: 'resumeMemberAggregation',
-    key: null
+    clientMethod: 'resumeMemberAggregation'
   },
   {
     method: 'get',
     url: '/users/:userGuid/members/:memberGuid/challenges',
-    clientMethod: 'listMemberChallenges',
-    key: 'credentials'
+    clientMethod: 'listMemberChallenges'
   },
   {
     method: 'get',
     url: '/users/:userGuid/members/:memberGuid/status',
-    clientMethod: 'checkMemberStatus',
-    key: 'member'
+    clientMethod: 'checkMemberStatus'
   },
   {
     method: 'get',
     url: '/users/:userGuid/accounts',
-    clientMethod: 'listAccounts',
-    key: 'accounts'
+    clientMethod: 'listAccounts'
   },
   {
     method: 'get',
     url: '/users/:userGuid/accounts/:accountGuid',
-    clientMethod: 'readAccount',
-    key: 'account'
+    clientMethod: 'readAccount'
   },
   {
     method: 'get',
     url: '/users/:userGuid/accounts/:accountGuid/transactions',
-    clientMethod: 'listAccountTransactions',
-    key: 'transactions'
+    clientMethod: 'listAccountTransactions'
   },
   //Holdings
   {
     method: 'get',
     url: '/users/:userGuid/holdings',
-    clientMethod: 'listHoldings',
-    key: 'holdings'
+    clientMethod: 'listHoldings'
   },
   {
     method: 'get',
     url: '/users/:userGuid/holdings/:holdingGuid',
-    clientMethod: 'readHolding',
-    key: 'holding'
+    clientMethod: 'readHolding'
   },
   //Transactions
   {
     method: 'get',
     url: '/users/:userGuid/transactions',
-    clientMethod: 'listTransactions',
-    key: 'transactions'
+    clientMethod: 'listTransactions'
   },
   {
     method: 'get',
     url: '/users/:userGuid/transactions/:transactionGuid',
-    clientMethod: 'readTransaction',
-    key: 'transaction'
+    clientMethod: 'readTransaction'
   },
 
 ];


### PR DESCRIPTION
This removes the key from the endpoint object. It was being used in the server file to return the only the fetched object, but that was making it return nothing on an error. 

This way, the express server returns either the response body object or an error.
