### PR TITLE
Added search prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,10 @@ Atrium.Client.prototype.listInstitutions = function () {
   return this._fetchUtility('institutions', 'GET');
 };
 
+Atrium.Client.prototype.searchInstitutions = function (request) {
+  return this._fetchUtility('institutions?name=' + request.params.institutionName, 'GET');
+};
+
 //Credentials
 //Fix Institution param
 Atrium.Client.prototype.listCredentials = function (request) {


### PR DESCRIPTION
In the atrium documentation, the name is available to be able to search for an institution but it was missing in this module. Added a prototype to handle an institutionName if provided to find a matching institution by a search query.