### PR TITLE
fix AtriumClient typings to include subresource definitions

### DIFF
--- a/atrium.d.ts
+++ b/atrium.d.ts
@@ -1318,4 +1318,15 @@ export declare class VerificationApi {
 export declare class AtriumClient {
     constructor(apiKey: any, clientID: any);
     mount(label: any, val: any, apiKey: any, clientID: any): void;
+    accounts: AccountsApi
+    connectWidget: ConnectWidgetApi
+    holdings: HoldingsApi
+    identity: IdentityApi
+    institutions: InstitutionsApi
+    members: MembersApi
+    merchants: MerchantsApi
+    statements: StatementsApi
+    transactions: TransactionsApi
+    users: UsersApi
+    verification: VerificationApi
 }


### PR DESCRIPTION
The AtriumClient needs to have definitions for all the various subresource APIs in order for the typescript typings to work. I'm not sure how these were generated, or if this is right place to be updating this, so please let me know so that I can fix it asap. Thanks ☘️  