### PR TITLE
Don't publish typescript files

### DIFF
--- a/atrium.ts
+++ b/atrium.ts
@@ -5594,7 +5594,7 @@ export class VerificationApi {
 }
 
 export class AtriumClient {
-    constructor(apiKey, clientID) { 
+    constructor(apiKey: string, clientID: string) {
         this.mount('accounts', new AccountsApi(), apiKey, clientID);
         this.mount('connectWidget', new ConnectWidgetApi(), apiKey, clientID);
         this.mount('holdings', new HoldingsApi(), apiKey, clientID);
@@ -5608,7 +5608,7 @@ export class AtriumClient {
         this.mount('verification', new VerificationApi(), apiKey, clientID);
     }
 
-    mount(label, val, apiKey, clientID) {
+    mount(label: keyof AtriumClient, val: any, apiKey: string, clientID: string) {
         val.setApiKey(0, apiKey);
         val.setApiKey(1, clientID);
         this[label] = val;

--- a/package.json
+++ b/package.json
@@ -8,9 +8,15 @@
     "scripts": {
         "clean": "rm -rf node_modules/ *.js",
         "build": "tsc",
-        "test": "npm run build && node client.js",
-        "prepublish": "rm **/**/*.ts"
+        "test": "npm run build && node client.js"
     },
+    "files": [
+        "atrium.d.ts",
+        "atrium.js",
+        "atrium.js.map",
+        "LICENSE",
+        "README.md"
+    ],
     "author": "MX",
     "license": "MIT",
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "main": "atrium.js",
     "types": "api.d.ts",
     "scripts": {
-        "clean": "rm -Rf node_modules/ *.js",
+        "clean": "rm -rf node_modules/ *.js",
         "build": "tsc",
-        "test": "npm run build && node client.js"
+        "test": "npm run build && node client.js",
+        "prepublish": "rm **/**/*.ts"
     },
     "author": "MX",
     "license": "MIT",


### PR DESCRIPTION
The published typescript file `atrium.ts` is causing issues with our development environment - it's getting included in our source code and conflicting with our compilation rules.

Here's an example of that happening: https://github.com/Microsoft/TypeScript/issues/15363

These changes will instead publish only the files specified in `package.json`
```
    "files": [
        "atrium.d.ts",
        "atrium.js",
        "atrium.js.map",
        "LICENSE",
        "README.md"
    ]
```

Also added some missing types to the typescript file, which was ultimately causing issues with our environment (no implicit any)