### PR TITLE
Add ability to change to prod env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please see `docs` directory for additional endpoint examples
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var accountGuid = "ACT-123"; // string | The unique identifier for an `account`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/atrium.ts
+++ b/atrium.ts
@@ -5670,18 +5670,18 @@ export class VerificationApi {
 }
 
 export class AtriumClient {
-    constructor(apiKey: string, clientID: string) {
-        this.mount('accounts', new AccountsApi(), apiKey, clientID);
-        this.mount('connectWidget', new ConnectWidgetApi(), apiKey, clientID);
-        this.mount('holdings', new HoldingsApi(), apiKey, clientID);
-        this.mount('identity', new IdentityApi(), apiKey, clientID);
-        this.mount('institutions', new InstitutionsApi(), apiKey, clientID);
-        this.mount('members', new MembersApi(), apiKey, clientID);
-        this.mount('merchants', new MerchantsApi(), apiKey, clientID);
-        this.mount('statements', new StatementsApi(), apiKey, clientID);
-        this.mount('transactions', new TransactionsApi(), apiKey, clientID);
-        this.mount('users', new UsersApi(), apiKey, clientID);
-        this.mount('verification', new VerificationApi(), apiKey, clientID);
+    constructor(apiKey: string, clientID: string, basePath: string = defaultBasePath) {
+        this.mount('accounts', new AccountsApi(basePath), apiKey, clientID);
+        this.mount('connectWidget', new ConnectWidgetApi(basePath), apiKey, clientID);
+        this.mount('holdings', new HoldingsApi(basePath), apiKey, clientID);
+        this.mount('identity', new IdentityApi(basePath), apiKey, clientID);
+        this.mount('institutions', new InstitutionsApi(basePath), apiKey, clientID);
+        this.mount('members', new MembersApi(basePath), apiKey, clientID);
+        this.mount('merchants', new MerchantsApi(basePath), apiKey, clientID);
+        this.mount('statements', new StatementsApi(basePath), apiKey, clientID);
+        this.mount('transactions', new TransactionsApi(basePath), apiKey, clientID);
+        this.mount('users', new UsersApi(basePath), apiKey, clientID);
+        this.mount('verification', new VerificationApi(basePath), apiKey, clientID);
     }
 
     mount(label: keyof AtriumClient, val: any, apiKey: string, clientID: string) {

--- a/docs/AccountsApi.md
+++ b/docs/AccountsApi.md
@@ -19,7 +19,7 @@ This endpoint allows you to see every transaction that belongs to a specific acc
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var accountGuid = "ACT-123"; // string | The unique identifier for an `account`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -63,7 +63,7 @@ Use this endpoint to view information about every account that belongs to a user
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 var page = 1; // number | Specify current page. (optional)
@@ -101,7 +101,7 @@ Reading an account allows you to get information about a specific account that b
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var accountGuid = "ACT-123"; // string | The unique identifier for an `account`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -137,7 +137,7 @@ Reading an account allows you to get information about a specific account that b
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var accountGuid = "ACT-123"; // string | The unique identifier for an `account`.
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.

--- a/docs/ConnectWidgetApi.md
+++ b/docs/ConnectWidgetApi.md
@@ -16,7 +16,7 @@ This endpoint will return a URL for an embeddable version of MX Connect.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 var body = new atrium.ConnectWidgetRequestBody(); // ConnectWidgetRequestBody | Optional config options for WebView (is_mobile_webview, current_institution_code, current_member_guid, update_credentials)

--- a/docs/HoldingsApi.md
+++ b/docs/HoldingsApi.md
@@ -19,7 +19,7 @@ Use this endpoint to read all holdings associated with a specific user.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 
@@ -53,7 +53,7 @@ Use this endpoint to read all holdings associated with a specific account.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var accountGuid = "ACT-123"; // string | The unique identifier for an `account`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -89,7 +89,7 @@ Use this endpoint to read all holdings associated with a specific member.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -125,7 +125,7 @@ Use this endpoint to read the attributes of a specific holding.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var holdingGuid = "HOL-123"; // string | The unique identifier for a `holding`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/docs/IdentityApi.md
+++ b/docs/IdentityApi.md
@@ -17,7 +17,7 @@ The identify endpoint begins an identification process for an already-existing m
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -53,7 +53,7 @@ This endpoint returns an array with information about every account associated w
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/docs/InstitutionsApi.md
+++ b/docs/InstitutionsApi.md
@@ -18,7 +18,7 @@ This endpoint allows you to see what institutions are available for connection. 
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var name = name_example; // string | This will list only institutions in which the appended string appears. (optional)
 var page = 1; // number | Specify current page. (optional)
@@ -64,7 +64,7 @@ This endpoint allows you to see information for a specific institution.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var institutionCode = "example_institution_code"; // string | The institution_code of the institution.
 
@@ -98,7 +98,7 @@ Use this endpoint to see which credentials will be needed to create a member for
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var institutionCode = "example_institution_code"; // string | The institution_code of the institution.
 

--- a/docs/MembersApi.md
+++ b/docs/MembersApi.md
@@ -29,7 +29,7 @@ Calling this endpoint initiates an aggregation event for the member. This brings
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -65,7 +65,7 @@ This endpoint operates much like the _aggregate member_ endpoint except that it 
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -101,7 +101,7 @@ This endpoint allows you to create a new member. Members are created with the re
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 var body = new atrium.MemberCreateRequestBody(); // MemberCreateRequestBody | Member object to be created with optional parameters (identifier and metadata) and required parameters (credentials and institution_code)
@@ -137,7 +137,7 @@ Accessing this endpoint will permanently delete a member.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -173,7 +173,7 @@ The extend_history endpoint begins the process of fetching up to 24 months of da
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -209,7 +209,7 @@ This endpoint returns an array with information about every account associated w
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -249,7 +249,7 @@ This endpoint returns an array which contains information on every non-MFA crede
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -285,7 +285,7 @@ Use this endpoint for information on what multi-factor authentication challenges
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -321,7 +321,7 @@ Use this endpoint to get all transactions from all accounts associated with a sp
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -365,7 +365,7 @@ This endpoint returns an array which contains information on every member associ
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 var page = 1; // number | Specify current page. (optional)
@@ -403,7 +403,7 @@ Use this endpoint to read the attributes of a specific member.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -439,7 +439,7 @@ This endpoint provides the status of the member's most recent aggregation event.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -475,7 +475,7 @@ This endpoint answers the challenges needed when a member has been challenged by
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -513,7 +513,7 @@ Use this endpoint to update a member's attributes. Only the credentials, identif
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/docs/MerchantsApi.md
+++ b/docs/MerchantsApi.md
@@ -16,7 +16,7 @@ Returns information about a particular merchant, such as a logo, name, and websi
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var merchantGuid = "MCH-123"; // string | The unique identifier for a `merchant`.
 

--- a/docs/StatementsApi.md
+++ b/docs/StatementsApi.md
@@ -19,7 +19,7 @@ Use this endpoint to download a specified statement. The endpoint URL is the sam
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -57,7 +57,7 @@ The fetch statements endpoint begins fetching statements for a member.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -93,7 +93,7 @@ Certain institutions in Atrium allow developers to access account statements ass
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -133,7 +133,7 @@ Use this endpoint to download a specified statement. The endpoint URL is the sam
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/docs/TransactionsApi.md
+++ b/docs/TransactionsApi.md
@@ -18,7 +18,7 @@ Use this endpoint to categorize, cleanse, and classify transactions. These trans
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var body = new atrium.TransactionsCleanseAndCategorizeRequestBody(); // TransactionsCleanseAndCategorizeRequestBody | User object to be created with optional parameters (amount, type) amd required parameters (description, identifier)
 
@@ -52,7 +52,7 @@ Use this endpoint to get all transactions that belong to a specific user, across
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 var page = 1; // number | Specify current page. (optional)
@@ -94,7 +94,7 @@ This endpoint allows you to view information about a specific transaction that b
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var transactionGuid = "TRN-123"; // string | The unique identifier for a `transaction`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/docs/UsersApi.md
+++ b/docs/UsersApi.md
@@ -20,7 +20,7 @@ Call this endpoint to create a new user. Atrium will respond with the newly-crea
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var body = new atrium.UserCreateRequestBody(); // UserCreateRequestBody | User object to be created with optional parameters (identifier, is_disabled, metadata)
 
@@ -54,7 +54,7 @@ Calling this endpoint will permanently delete a user from Atrium. If successful,
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 
@@ -88,7 +88,7 @@ Use this endpoint to list every user you've created in Atrium.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var page = 1; // number | Specify current page. (optional)
 var recordsPerPage = 12; // number | Specify records per page. (optional)
@@ -124,7 +124,7 @@ Use this endpoint to read the attributes of a specific user.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 
@@ -158,7 +158,7 @@ Use this endpoint to update the attributes of a specific user. Atrium will respo
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
 var body = new atrium.UserUpdateRequestBody(); // UserUpdateRequestBody | User object to be updated with optional parameters (identifier, is_disabled, metadata) (optional)

--- a/docs/VerificationApi.md
+++ b/docs/VerificationApi.md
@@ -18,7 +18,7 @@ Use this endpoint to check whether account and routing numbers are available for
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -54,7 +54,7 @@ Use this endpoint to check whether account and routing numbers are available for
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var accountGuid = "ACT-123"; // string | The unique identifier for an `account`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.
@@ -90,7 +90,7 @@ The verify endpoint begins a verification process for a member.
 ```javascript
 var atrium = require('./atrium.js');
 
-var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+var client = new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 var memberGuid = "MBR-123"; // string | The unique identifier for a `member`.
 var userGuid = "USR-123"; // string | The unique identifier for a `user`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mx-atrium",
-    "version": "2.9.1",
+    "version": "2.9.2",
     "description": "NodeJS client for mx-atrium-node",
     "repository": "mxenabled/mx-atrium-node",
     "main": "atrium.js",


### PR DESCRIPTION
Adds ability to change to prod env by initializing the client with an
optional env parameter (defaults to vestibule if not provided)

Example `new atrium.AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://atrium.mx.com");`

@peppys 